### PR TITLE
Sudo abhängigkeit entfernen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ addons:
     - luarocks
   
 install:
-  - luarocks install lua-cjson
+  - eval $(luarocks path --bin)
+  - luarocks install --local lua-cjson
 
 script:
   - bash tests/validate_site.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: bash
 
-sudo: true
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install lua5.1 luarocks
+addons:
+  apt:
+    packages:
+    - lua5.1
+    - luarocks
   
 install:
-  - sudo luarocks install lua-cjson
+  - luarocks install lua-cjson
 
 script:
   - bash tests/validate_site.sh


### PR DESCRIPTION
Travis sollte auch ohne sudo laufen da es container basiert ist. das entfernt die meldung  `This job ran on our Precise, sudo: required environment which was updated on May 4th. Please check our blog for more details about this update.`